### PR TITLE
Support multiple datastore for single actor, and cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,16 +92,16 @@ B -- "publish_obs()" --> A
 2. **Trainer compute as server: `agentlace.TrainerServer` and `agentlace.TrainerClient`**
    - `TrainerClient` provides consistent datastore update to server and gets new network
 
-This supports distributed datastore, and enable multiple clients to send data to server. The server can then publish the new network to all clients.
+This enables distributed datastore (ds1 and ds2), and enables multiple clients to send data to server. The server can then publish the new network to all clients.
 
 *Clients keep their own instance of their datastore, call the `update()` method to provide the latest datastore update to the trainer server via an internal datastore (ReplayBuffer). The trainer retrieve data from the datastore and provide the trained network to client via `publish_network()` method*
 
 ```mermaid
 graph LR
-A[ActorA - client] -- "update()" --> B((Learner - \n Trainer Server))
+A[ActorA - client ds1] -- "update()" --> B((Learner - \n Trainer Server, \n ds1 ds2))
 B -- "publish_network()" --> A
 A -- "send_request()" --> B
-G[ActorB - client] <--> B
+G[ActorB - client ds2] <--> B
 ```
 
 1. **Inference compute as server: `agentlace.InferenceServer` and `agentlace.InferenceClient`**
@@ -259,3 +259,15 @@ pytest-3 agentlace/tests/test_data_store.py
 ```
 
 - The current implementation mainly uses zeromq as communication protocol, it should be easy to extend it to support other protocols such as grpc. (TODO: impl abstract function when there is a need)
+
+## Citation
+
+```bibtex
+@software{agentlace2024,
+  author = {You Liang Tan},
+  title = {Agentlace, framework for distributed agent policy},
+  month = May,
+  year = 2024,
+  url = {https://github.com/youliangtan/agentlace},
+}
+```

--- a/agentlace/trainer.py
+++ b/agentlace/trainer.py
@@ -146,19 +146,25 @@ class TrainerClient:
                  name: str,
                  server_ip: str,
                  config: TrainerConfig,
-                 data_store: DataStoreBase,
+                 data_store: DataStoreBase = None,
+                 data_stores: Dict[str, DataStoreBase] = {},
                  log_level=logging.INFO,
                  wait_for_server: bool = False):
         """
         Args:
-            :param name: Name of the client, creates a unique datastore
+            :param name: Name of the client
             :param server_ip: IP address of the server
             :param config: Config object
-            :param data_store: Datastore to store the data
+            :param data_store: Datastore to store the data (deprecated soon)
+            :param data_stores: Map of data stores
             :param log_level: Logging level
             :param wait_for_server: Whether to wait for the server to start
+
+        Note:
+            name, and data_store will deprecate in future versions, to support
+            multiple data stores in single client, use `data_stores_map` instead.
         """
-        self.name = name
+        self.client_name = name
         self.req_rep_client = ReqRepClient(server_ip, config.port_number, log_level=log_level)
         self.server_ip = server_ip
         self.config = config
@@ -168,8 +174,12 @@ class TrainerClient:
         self.update_thread = None
         self.last_request_time = 0
         self.log_level = log_level
-        logging.basicConfig(level=log_level)
 
+        # for multiple data stores
+        self.data_stores_map = data_stores  # dict of str -> DataStoreBase
+        self.last_sync_data_id_map = {name: -1 for name in self.data_stores_map.keys()}
+
+        logging.basicConfig(level=log_level)
         res = self.req_rep_client.send_msg({"type": "hash"})
 
         # If wait for server
@@ -201,24 +211,42 @@ class TrainerClient:
         This will explicity trigger an update to the data store
             :return Response from the trainer, return None if timeout
         """
-        latest_id = self.data_store.latest_data_id()
-        batch_data = self.data_store.get_latest_data(self.last_sync_data_id)
-        res = self._update({"data": batch_data})
-        if res and res["success"]:
-            self.last_sync_data_id = latest_id
-        else:
-            logging.warning("Failed to update data")
-        return res
+        if self.data_store is not None:
+            latest_id = self.data_store.latest_data_id()
+            batch_data = self.data_store.get_latest_data(self.last_sync_data_id)
+            res = self._update_ds(self.client_name, {"data": batch_data})
+            if res and res["success"]:
+                self.last_sync_data_id = latest_id
+            else:
+                logging.warning("Failed to update data")
+            return res
 
-    def _update(self, data: dict) -> Optional[dict]:
+        # if multiple data stores is used
+        # TODO (YL): robust test this feature
+        elif self.data_stores_map:
+            res = {}
+            for name, data_store in self.data_stores_map.items():
+                _latest_id = data_store.latest_data_id()
+                _last_sync_id = self.last_sync_data_id_map[name]
+                batch_data = data_store.get_latest_data(_last_sync_id)
+                res = self._update_ds(name, {"data": batch_data})
+                if res and res["success"]:
+                    self.last_sync_data_id_map[name] = _latest_id
+                else:
+                    # return failed response if any of the data store fails
+                    logging.warning("Failed to update data")
+                    return res
+            return res  # return the last response
+        return None
+
+    def _update_ds(self, name: str, data: dict) -> Optional[dict]:
         """
         internal update method that will send the data to the server
+            :name Name of the data store
             :param data: Payload to send to the trainer
             :return: Response from the trainer, return None if timeout
         """
-        msg = {"type": "data",
-               "store_name": self.name,
-               "payload": data}
+        msg = {"type": "data", "store_name": name, "payload": data}
         if self.config.rate_limit and \
                 time.time() - self.last_request_time < 1 / self.config.rate_limit:
             logging.warning("Rate limit exceeded")
@@ -236,8 +264,7 @@ class TrainerClient:
         """
         if type not in self.request_types:
             return None
-        msg = {"type": type,
-               "payload": payload}
+        msg = {"type": type, "payload": payload}
         if self.config.rate_limit and \
                 time.time() - self.last_request_time < 1 / self.config.rate_limit:
             logging.warning("Rate limit exceeded")
@@ -278,13 +305,16 @@ class TrainerClient:
 
 ##############################################################################
 
-class TrainerTunnel:
+
+class TrainerSMInterface:
     """
-    This is a simple implementation to recreate the transport layer interface
-    of TrainerServer and TrainerClient. Helpful to test multithreaded operation
-    for TrainerServer and TrainerClient, while sharing the same datastore.
+    Utilized shared-memory to recreate the transport layer interface
+    of TrainerServer and TrainerClient. Helpful for single-process
+    multithreaded operation, while maintaining the same interface as
+    the TrainerServer and TrainerClient.
         NOTE: this suppose to be an experimental feature
     """
+
     def __init__(self):
         self._recv_network_fn = None
         self._req_callback_fn = None
@@ -299,14 +329,14 @@ class TrainerTunnel:
             self._recv_network_fn(params)
 
     def start(self, *args, **kwargs):
-        pass # Do nothing
+        pass  # Do nothing
 
     def stop(self):
-        pass # Do nothing
+        pass  # Do nothing
 
     def update(self):
         """Refer to TrainerClient.update()"""
-        pass # Do nothing since assume shared datastore
+        pass  # Do nothing since assume shared datastore
 
     def register_request_callback(self, callback_fn: Callable):
         """A impl within TrainerServer.init()"""
@@ -317,7 +347,7 @@ class TrainerTunnel:
         if self._req_callback_fn:
             return self._req_callback_fn(type, payload)
         return None
-    
+
     def start_async_update(self, interval: int = 10):
         """
         Refer to TrainerClient.start_async_update()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='agentlace',
-    version='0.1.2',
+    version='0.1.3',
     packages=find_packages(),
     description='library to enable distributed agent for ml training and inference',
     url='https://github.com/youliangtan/agentlace',


### PR DESCRIPTION
- Support multiple datastore for single actor node:
```py
class TrainerClient:
        def __init__(self, ........
                 data_store: DataStoreBase = None,   # DEPRECATED
                 data_stores: Dict[str, DataStoreBase] = {},   # NEW
         ):

# example to add multiple datastores
tc = TrainerClient(...., data_stores={"table1": ds_client, "table2": ds_client2})
```
- rename `TrainerTunnel` to `TrainerSMInterface`, more verbose since we are using shared memory.
- misc cleanups and improvs.
