### PR TITLE
fix bugs in populate_datastore from rlds data

### DIFF
--- a/agentlace/data/tfds.py
+++ b/agentlace/data/tfds.py
@@ -12,7 +12,10 @@ from agentlace.data.data_store import DataStoreBase
 
 
 def make_datastore(
-    dataset_dir, capacity: int, type="replay_buffer"
+    dataset_dir,
+    capacity: int,
+    type="replay_buffer",
+    data_transform: Optional[DataTransformFunction] = None,
 ) -> DataStoreBase:
     """
     Load an RLDS dataset from the specified directory and populate it
@@ -21,8 +24,8 @@ def make_datastore(
     Args:
         - dataset_dir: Directory where the RLDS dataset is stored.
         - capacity: Capacity of the replay buffer.
-        - type: supported types are "replay_buffer" and "trajectory_buffer"
-
+        - type: supported types are "replay_buffer", "trajectory_buffer"
+                and "queued_datastore"
     Returns:
         - datastore: Datastore populated with the RLDS dataset.
     """
@@ -50,10 +53,15 @@ def make_datastore(
             action_space=tensor_spec_to_gym_space(action_tensor_spec),
             capacity=capacity,
         )
+    elif type == "queued_datastore":
+        from agentlace.data.data_store import QueuedDataStore
+        datastore = QueuedDataStore(
+            capacity=capacity,
+        )
     else:
         raise ValueError(f"Unsupported type: {type}")
 
-    return populate_datastore(datastore, dataset, type)
+    return populate_datastore(datastore, dataset, type, data_transform)
 
 
 """
@@ -92,26 +100,41 @@ def populate_datastore(
     step_keys = dataset.element_spec["steps"].element_spec.keys()
     metadata_keys = [k for k in step_keys if k not in [
         'observation', 'action', 'reward', 'is_terminal', 'is_last']]
-    # print("metadata_keys: ", metadata_keys)
+
+    # Transform the data if user provided a data_transform function
+    # NOTE: the arg data is a dict of the data inserted into the datastore
+    # and the metadata is a dict of the metadata extracted from the step
+    # which are not part of data
+    def handle_custom_data_transform(data, step, step_size, step_idx):
+        if data_transform is None: # do nothing
+            return data
+
+        metadata = dict(step=step_idx, step_size=step_size)
+        for key in metadata_keys:
+            metadata[key] = get_value_from_tensor(step[key])
+        return data_transform(data, metadata)
 
     # Iterate over episodes in the dataset
-    reward, terminate, truncate = None, None, None
+    prev_step = None
     for episode in dataset:
         steps = episode['steps']
         obs = None
         _step_size = len(steps)
+
         # Iterate through steps in the episode
         for i, step in enumerate(steps):
             if i == 0:
-                obs = get_value_from_tensor(step['observation'])
-                action = get_value_from_tensor(step['action'])
-                reward = step.get('reward', 0.).numpy() # default 0 if 'reward' key is missing
-                terminate = step['is_terminal'].numpy()  # or is_last
-                truncate = step['is_last'].numpy() # truncate is not avail in the ReplayBuffer
+                prev_step = step
                 continue
 
             # extract data from the step to insert into the datastore
-            next_obs = get_value_from_tensor(step['observation'])
+            obs = get_value_from_tensor(prev_step['observation'])
+            action = get_value_from_tensor(prev_step['action'])
+            reward = prev_step.get('reward', 0.).numpy() # default 0 if 'reward' key is missing
+            terminate = prev_step['is_terminal'].numpy()  # or is_last
+            truncate = prev_step['is_last'].numpy() # truncate is not avail in the ReplayBuffer
+            next_obs = get_value_from_tensor(step['observation'])  # NOTE: use curr step
+
             data = dict(
                 observations=obs,
                 next_observations=next_obs,
@@ -124,38 +147,43 @@ def populate_datastore(
             elif type == "with_dones":
                 data["dones"] = terminate or truncate
 
-            action = get_value_from_tensor(step['action'])
-            reward = step.get('reward', 0.).numpy() # default 0 if 'reward' key is missing
-            terminate = step['is_terminal'].numpy()  # or is_last
-            truncate = step['is_last'].numpy() # truncate is not avail in the ReplayBuffer
+            # intermediate step in RLDS shouldn't be terminal or truncate
+            assert not terminate, "intermediate step should not be terminal"
+            assert not truncate, "intermediate step should not be truncate"
 
-            # TODO: check if terminate and truncate are recorded in the final
-            # data inserted into the datastore
-            if terminate or truncate:
-                pass
+            data = handle_custom_data_transform(data, prev_step, _step_size, i-1)
 
-            # Transform the data if user provided a data_transform function
-            # NOTE: the arg data is a dict of the data inserted into the datastore
-            # and the metadata is a dict of the metadata extracted from the step
-            # which are not part of data
-            if data_transform is not None:
-                metadata = dict(
-                    step=i, # -1 # TODO
-                    step_size=_step_size,
-                )
-                for key in metadata_keys:
-                    metadata[key] = get_value_from_tensor(step[key])
-                data = data_transform(data, metadata)
+            # data is None, expect user would like to skip this data point
+            if data is not None:
+                datastore.insert(data)
+            prev_step = step
 
-                # data is None, expect use would like to skip this data point
-                if data is None:
-                    obs = next_obs
-                    continue
+        # Special handling of the last step of the episode
+        if prev_step:
+            obs = get_value_from_tensor(prev_step['observation'])
+            action = get_value_from_tensor(prev_step['action'])
+            reward = prev_step.get('reward', 0.).numpy()
+            terminate = prev_step['is_terminal'].numpy()  # or is_last
+            truncate = prev_step['is_last'].numpy() # truncate is not avail in the ReplayBuffer
+            data = dict(
+                observations=obs,
+                next_observations=obs, # invalid during the last step
+                actions=action,        # invalid during the last step
+                rewards=reward,
+                masks=1 - terminate,  # 1 is transition, 0 is terminal
+            )
+            if type == "trajectory_buffer":
+                data["end_of_trajectory"] = terminate or truncate
+            elif type == "with_dones":
+                data["dones"] = terminate or truncate
+            assert terminate or truncate, "last step should be terminal or truncate"
 
-            # print("data: ", data['actions'], data['rewards'], data['masks'], data['dones'])
-            # Insert data into the replay buffer
-            datastore.insert(data)
-            obs = next_obs
+            data = handle_custom_data_transform(data, prev_step, _step_size, _step_size-1)
+
+            # data is None, expect use would like to skip this data point
+            if data is not None:
+                datastore.insert(data)
+
     return datastore
 
 ##############################################################################

--- a/agentlace/data/tfds.py
+++ b/agentlace/data/tfds.py
@@ -5,6 +5,7 @@ import numpy as np
 import tensorflow as tf
 import tensorflow_datasets as tfds
 from typing import Dict, Optional, Callable
+import warnings
 
 from agentlace.data.data_store import DataStoreBase
 
@@ -148,8 +149,8 @@ def populate_datastore(
                 data["dones"] = terminate or truncate
 
             # intermediate step in RLDS shouldn't be terminal or truncate
-            assert not terminate, "intermediate step should not be terminal"
-            assert not truncate, "intermediate step should not be truncate"
+            if terminate or truncate:
+                warnings.warn("Intermediate step should not be terminal or truncate")
 
             data = handle_custom_data_transform(data, prev_step, _step_size, i-1)
 
@@ -176,7 +177,9 @@ def populate_datastore(
                 data["end_of_trajectory"] = terminate or truncate
             elif type == "with_dones":
                 data["dones"] = terminate or truncate
-            assert terminate or truncate, "last step should be terminal or truncate"
+
+            if not terminate and not truncate:
+                warnings.warn("Last step should be terminal or truncate")
 
             data = handle_custom_data_transform(data, prev_step, _step_size, _step_size-1)
 

--- a/agentlace/data/trajectory_buffer.py
+++ b/agentlace/data/trajectory_buffer.py
@@ -131,10 +131,6 @@ class TrajectoryBuffer:
                 end_of_trajectory=False,                            # is last
             )
         """
-        end_of_trajectory = data.pop(
-            "end_of_trajectory", end_of_trajectory
-        )  # TODO: if not exist, assume False
-
         # Grab the metadata of the sample we're overwriting
         real_insert_idx = self._insert_idx % self.capacity
         overwritten_ep_end = self.metadata["ep_end"][real_insert_idx]

--- a/examples/async_learner_actor.py
+++ b/examples/async_learner_actor.py
@@ -42,7 +42,7 @@ flags.DEFINE_integer("replay_buffer_capacity", 1000000, "Replay buffer capacity.
 
 flags.DEFINE_integer("random_steps", 500, "Sample random actions for this many steps.")
 flags.DEFINE_integer("training_starts", 1000, "Training starts after this step.")
-flags.DEFINE_integer("steps_per_update", 10, "Number of steps per update the server.")
+flags.DEFINE_integer("steps_per_update", 50, "Number of steps per update the server.")
 
 flags.DEFINE_integer("log_period", 10, "Logging period.")
 flags.DEFINE_integer("eval_period", 10000, "Evaluation period.")


### PR DESCRIPTION
The `populate_datastore()` function was dealing with the rlds data incorrectly:

 - the previous action was corresponding to the next_obs, which is incorrect. fix it as the action is correspond to current obs.
 - fix terminal and truncated state data. and fix data_transform callback missing of step 0.

Refer to here: https://github.com/google-research/rlds