### PR TITLE
Experimental Zmq Pipeline for ds update

### DIFF
--- a/agentlace/zmq_wrapper/pipeline.py
+++ b/agentlace/zmq_wrapper/pipeline.py
@@ -1,0 +1,106 @@
+"""
+Pipe method is a simple way to send data from one process to another.
+Different to ReqRep, pipe doesnt require a response from the receiver.
+The PUSH socket sends messages to the PULL socket
+
+https://zeromq.org/socket-api/#pipeline-pattern
+https://learning-0mq-with-pyzmq.readthedocs.io/en/latest/pyzmq/patterns/pushpull.html
+"""
+
+import zmq
+import argparse
+import numpy as np
+import time
+import threading
+import logging
+from typing import Callable
+
+from agentlace.internal.utils import make_compression_method
+
+
+DEFAULT_PIPE_URL = "tcp://127.0.0.1:5547"
+
+##############################################################################
+
+
+class Producer:
+    """Message producer for pipe communication."""
+
+    def __init__(self, url=DEFAULT_PIPE_URL, compression: str = 'lz4'):
+        logging.debug("Initializing pipe producer with url: ", url)
+        context = zmq.Context()
+        self.zmq_socket = context.socket(zmq.PUSH)
+        self.zmq_socket.connect(url)
+        self.compress, self.decompress = make_compression_method(compression)
+
+    def send_msg(self, msg):
+        msg = self.compress(msg)
+        self.zmq_socket.send(msg)
+
+##############################################################################
+
+
+class Consumer:
+    """Message consumer for pipe communication."""
+
+    def __init__(self, callback_fn: Callable, url=DEFAULT_PIPE_URL, compression: str = 'lz4'):
+        logging.debug("Initializing pipe consumer with url: ", url)
+        context = zmq.Context()
+        self.results_receiver = context.socket(zmq.PULL)
+        self.results_receiver.bind(url)
+        self.callback_fn = callback_fn
+        self.compress, self.decompress = make_compression_method(compression)
+
+    def start(self):
+        """blocking start method."""
+        self.is_kill = False
+        while self.is_kill is False:
+            message = self.results_receiver.recv()
+            message = self.decompress(message)
+            self.callback_fn(message)
+
+    def async_start(self):
+        """non-blocking start method."""
+        self.thread = threading.Thread(target=self.start)
+        self.thread.start()
+
+    def stop(self):
+        self.is_kill = True
+        if self.thread:
+            self.thread.join()
+        self.results_receiver.close()
+
+
+##############################################################################
+
+if __name__ == "__main__":
+    # NOTE: This is just for Testing
+    parser = argparse.ArgumentParser(description='zmq producer')
+    parser.add_argument('--producer', action='store_true',
+                        help='run as producer')
+    parser.add_argument('--consumer', action='store_true',
+                        help='run as consumer')
+    args = parser.parse_args()
+
+    if args.consumer:
+        def callback_fn(result):
+            name = result["name"]
+            id = result["id"]
+            print("received ", name, id)
+
+        consumer = Consumer(callback_fn, url="tcp://100.78.214.136:5547")
+        consumer.async_start()
+        time.sleep(20)
+        print("Stopping consumer")
+        consumer.stop()
+
+    elif args.producer:
+        producer = Producer(url="tcp://127.0.0.1:5547")
+        payload = np.zeros(100)
+        for i in range(10):
+            time.sleep(0.5)
+            producer.send_msg({"name": "test", "id": i, "value": payload})
+    else:
+        print("Please specify --producer or --consumer")
+        parser.print_help()
+        exit(1)

--- a/agentlace/zmq_wrapper/req_rep.py
+++ b/agentlace/zmq_wrapper/req_rep.py
@@ -118,7 +118,7 @@ class ReqRepClient:
         self.socket.setsockopt(zmq.RCVTIMEO, self.timeout_ms)
         self.socket.connect(f"tcp://{self.ip}:{self.port}")
 
-    def send_msg(self, request: dict) -> Optional[str]:
+    def send_msg(self, request: dict, wait_for_response=True) -> Optional[str]:
         if self.socket is None or self.socket.closed:
             logging.debug("WARNING: Socket is closed, reseting...")
             return None
@@ -127,6 +127,8 @@ class ReqRepClient:
         with self._internal_lock:
             try:
                 self.socket.send(serialized)
+                if wait_for_response is False:
+                    return None
                 message = self.socket.recv()
                 return self.decompress(message)
             except Exception as e:

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -201,7 +201,7 @@ def stress_test_trainer():
         # show that speed up from 0.06 to 0.005 sec in stress test
         # experimental_pipeline_url="tcp://127.0.0.1:5547",
     )
-    curr_timeout = 100
+    curr_timeout = 5
     server = TrainerServer(trainer_config, new_data_callback, request_callback)
     ds_learner1 = helper_create_data_store(100000)
     ds_learner2 = helper_create_data_store(100000)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -80,8 +80,6 @@ def test_queued_data_store():
     data_id_9 = ds.latest_data_id()
     ds.batch_insert([10, 11, 12, 13, 14, 15, 16, 17])
     assert ds._data_queue[-1] == 17
-    print(ds.latest_data_id(), data_id_9)
-#    assert ds.latest_data_id() - data_id_9 == 6
 
 
 def test_trainer():
@@ -99,6 +97,7 @@ def test_trainer():
         port_number=5555,
         broadcast_port=5556,
         request_types=["get-stats"],
+        # experimental_pipeline_url="tcp://127.0.0.1:5547",
     )
     server = TrainerServer(trainer_config, new_data_callback, request_callback)
 
@@ -151,6 +150,7 @@ def test_trainer():
     assert len(ds_trainer2) == 0
     res = client.update()
     assert res, "Client update failed"
+    time.sleep(1)  # Give it a moment to send
     assert len(ds_trainer1) == 3
     assert len(ds_trainer2) == 2
 
@@ -197,7 +197,11 @@ def stress_test_trainer():
     trainer_config = TrainerConfig(
         port_number=5567,
         broadcast_port=5568,
+        # NOTE: use pipe for faster datastore update
+        # show that speed up from 0.06 to 0.005 sec in stress test
+        # experimental_pipeline_url="tcp://127.0.0.1:5547",
     )
+    curr_timeout = 100
     server = TrainerServer(trainer_config, new_data_callback, request_callback)
     ds_learner1 = helper_create_data_store(100000)
     ds_learner2 = helper_create_data_store(100000)
@@ -211,7 +215,6 @@ def stress_test_trainer():
     ds_actor1 = helper_create_data_store(100000)
     ds_actor2 = helper_create_data_store(100000)
 
-    curr_timeout = 5
     client = TrainerClient(
         'table1',
         '127.0.0.1',
@@ -228,11 +231,11 @@ def stress_test_trainer():
         insert_helper(ds_actor2, np.array([i]*100))
 
         if (i + 1) % 100 == 0:
+            start_time = time.time()
             res = client.update()
-            print(
-                f" Data store 1 length in actor vs learner: {len(ds_actor1)} vs {len(ds_learner1)}")
-            print(
-                f" Data store 2 length in actor vs learner: {len(ds_actor2)} vs {len(ds_learner2)}")
+            print(f"Update time: {time.time() - start_time}")
+            print(f" Datastore 1 actor vs learner: {len(ds_actor1)} vs {len(ds_learner1)}")
+            print(f" Datastore 2 actor vs learner: {len(ds_actor2)} vs {len(ds_learner2)}")
 
             assert len(ds_learner1) <= len(ds_actor1), \
                 "Data store in learner should be smaller than actor even when there's msg drop"
@@ -247,6 +250,8 @@ def stress_test_trainer():
 
         time.sleep(0.01)
 
+    print(f"~Final~ DataStore 1 actor vs learner: {len(ds_actor1)} vs {len(ds_learner1)}")
+    print(f"~Final~ DataStore 2 actor vs learner: {len(ds_actor2)} vs {len(ds_learner2)}")
     assert len(ds_actor1) == len(ds_learner1), "both ds should have the same length"
     assert len(ds_actor2) == len(ds_learner2), "both ds should have the same length"
     client.stop()


### PR DESCRIPTION
In the previous implementation of TrainerClient, when call `update()`, the datastore sync is done via req-res method. This synchronous operation makes it slow.

This PR introduces an experimental feature to use [zmq pipeline](https://stackoverflow.com/questions/12504559/zeromq-zmq-push-pull-pattern-usefulness) method for datastore sync between the trainer client and server.

The pipeline.py is a different communication protocol, which can run on a seperate thread to update the datastore when update() method is called. Also it is a one-way comm which doesnt require response to the client, thus faster.

(test script shows 0.06 vs 0.005 sec speed up)

This is currently an experimental feature, which can be enabled by:

```py
    trainer_config = TrainerConfig(
        port_number=5555,
        broadcast_port=5556,
        experimental_pipeline_url="tcp://127.0.0.1:5547", # SPECIFY THIS
    )
```