### PR TITLE
rename trainer pipeline from url to port

### DIFF
--- a/examples/async_learner_actor.py
+++ b/examples/async_learner_actor.py
@@ -42,7 +42,7 @@ flags.DEFINE_integer("replay_buffer_capacity", 1000000, "Replay buffer capacity.
 
 flags.DEFINE_integer("random_steps", 500, "Sample random actions for this many steps.")
 flags.DEFINE_integer("training_starts", 1000, "Training starts after this step.")
-flags.DEFINE_integer("steps_per_update", 50, "Number of steps per update the server.")
+flags.DEFINE_integer("steps_per_update", 30, "Number of steps per update the server.")
 
 flags.DEFINE_integer("log_period", 10, "Logging period.")
 flags.DEFINE_integer("eval_period", 10000, "Evaluation period.")

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -97,7 +97,7 @@ def test_trainer():
         port_number=5555,
         broadcast_port=5556,
         request_types=["get-stats"],
-        # experimental_pipeline_url="tcp://127.0.0.1:5547",
+        # experimental_pipeline_port=5547,
     )
     server = TrainerServer(trainer_config, new_data_callback, request_callback)
 
@@ -199,7 +199,7 @@ def stress_test_trainer():
         broadcast_port=5568,
         # NOTE: use pipe for faster datastore update
         # show that speed up from 0.06 to 0.005 sec in stress test
-        # experimental_pipeline_url="tcp://127.0.0.1:5547",
+        # experimental_pipeline_port=5547,
     )
     curr_timeout = 5
     server = TrainerServer(trainer_config, new_data_callback, request_callback)


### PR DESCRIPTION
Follow up from: https://github.com/youliangtan/agentlace/pull/13


Rename: `experimental_pipeline_url` to `experimental_pipeline_port`