### PR TITLE
add try-except statements to catch socket failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ __pycache__
 wandb/
 logs/
 .vscode/
-
+diff.txt

--- a/agentlace/zmq_wrapper/req_rep.py
+++ b/agentlace/zmq_wrapper/req_rep.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import zmq
+import time
 import argparse
 from typing import Optional, Dict
 from typing_extensions import Protocol


### PR DESCRIPTION
Better error handling for socket reset. 

This PR addresses the same issue as in [PR 18](https://github.com/youliangtan/agentlace/pull/18). The old fix was insufficient, while this fix is tested over ~1 months of continuous action server deployment. 